### PR TITLE
Adjusted unit tests to align with Controller responses

### DIFF
--- a/UnitTests/Controllers/EventControllerShould.cs
+++ b/UnitTests/Controllers/EventControllerShould.cs
@@ -90,8 +90,8 @@ namespace UnitTests.Controllers
             Assert.IsType<OkObjectResult>(task.Result);
 
             var result = task.Result as OkObjectResult;
-            var eventsResult = result.Value as Event;
-            Assert.Equal(evt2.description, eventsResult.description);
+            var eventResult = result.Value as bool?;
+            Assert.True(eventResult);
 
         }
 

--- a/UnitTests/Controllers/GuestControllerShould.cs
+++ b/UnitTests/Controllers/GuestControllerShould.cs
@@ -88,8 +88,8 @@ namespace UnitTests.Controllers
             Assert.IsType<OkObjectResult>(task.Result);
 
             var result = task.Result as OkObjectResult;
-            var guestResult = result.Value as Guest;
-            Assert.Equal(guest, guestResult);
+            var guestResult = result.Value as bool?;
+            Assert.True(guestResult);
         }
 
         [Fact]
@@ -108,8 +108,8 @@ namespace UnitTests.Controllers
             Assert.IsType<OkObjectResult>(task.Result);
 
             var result = task.Result as OkObjectResult;
-            var guestResult = result.Value as Guest;
-            Assert.Equal(guest, guestResult);
+            var guestResult = result.Value as bool?;
+            Assert.True(guestResult);
         }
 
         [Fact]
@@ -118,10 +118,10 @@ namespace UnitTests.Controllers
             // arrange
             var guest = new Guest { guestId = 123, name = "Guest1", email = "test1@psu.edu", isGoing = true, eventId = 1 };
 
-            _guestQueryMock.Setup(x => x.GetListByEventId(It.IsAny<int>()))
-                .Returns(Task.Factory.StartNew(() => new List<Guest> { guest }));
+            _guestQueryMock.Setup(x => x.GetByGuestId(It.IsAny<int>()))
+                .Returns(Task.Factory.StartNew(() => guest ));
 
-            _guestQueryMock.Setup(x => x.DeleteByEventId(It.IsAny<int>()))
+            _guestQueryMock.Setup(x => x.DeleteByGuestId(It.IsAny<int>()))
                 .Returns(Task.Factory.StartNew(() => true));
 
             // act

--- a/UnitTests/Controllers/UsersControllerShould.cs
+++ b/UnitTests/Controllers/UsersControllerShould.cs
@@ -136,8 +136,8 @@ namespace UnitTests.Controllers
             Assert.IsType<OkObjectResult>(task.Result);
 
             var result = task.Result as OkObjectResult;
-            var userResult = result.Value as string;
-            Assert.Equal("User successfully added.", userResult);
+            var userResult = result.Value as bool?;
+            Assert.True(userResult);
         }
 
 


### PR DESCRIPTION
I ran the unit tests this morning and saw a few were failing.  After a quick investigation, it looks like they were originally expecting the object to be returned whereas now they either return a OkObjectResult of true or a BadRequestResult.

To try to help out, I made some adjustments.  We can talk about the expected results later, but if we decide to just fix the tests based off of the current implementation this should do it.